### PR TITLE
Fix/bison ast

### DIFF
--- a/src/components/compiler/ast.c
+++ b/src/components/compiler/ast.c
@@ -105,6 +105,17 @@ t_ast_element *ast_string(char *value) {
 }
 
 
+t_ast_element *ast_string_dup(t_ast_element *src) {
+    t_ast_element *p = ast_alloc_element();
+
+    p->type = typeAstString;
+    p->string.value = smm_strdup(src->string.value);
+
+    return p;
+}
+
+
+
 /**
  * Creates a numerical node
  */

--- a/src/components/compiler/saffire.y
+++ b/src/components/compiler/saffire.y
@@ -166,9 +166,9 @@ use_statement:
         /* import <foo> as <bar> from <baz> */
     |   T_IMPORT namespace_identifier T_AS T_IDENTIFIER T_FROM namespace_identifier ';' { TRACE $$ = ast_opr(T_IMPORT, 3, $2, ast_string($4), $6); }
         /* import <foo> as <bar> */
-    |   T_IMPORT namespace_identifier T_AS T_IDENTIFIER                             ';' { TRACE $$ = ast_opr(T_IMPORT, 3, $2, ast_string($4), ast_nop()); }
+    |   T_IMPORT namespace_identifier T_AS T_IDENTIFIER                             ';' { TRACE $$ = ast_opr(T_IMPORT, 3, $2, ast_string($4), ast_string_dup($2)); }
         /* import <foo> */
-    |   T_IMPORT namespace_identifier                                               ';' { TRACE $$ = ast_opr(T_IMPORT, 3, $2, ast_nop(), ast_nop()); }
+    |   T_IMPORT namespace_identifier                                               ';' { TRACE $$ = ast_opr(T_IMPORT, 3, $2, ast_string_dup($2), ast_string_dup($2)); }
 ;
 
 

--- a/src/components/compiler/saffire.y
+++ b/src/components/compiler/saffire.y
@@ -483,18 +483,18 @@ method_call:
         qualified_name '.' T_IDENTIFIER     { TRACE $$ = ast_opr('.', 2, $1, ast_identifier($3)); smm_free($3); }
     |   special_name '.' T_IDENTIFIER       { TRACE $$ = ast_opr('.', 2, $1, ast_identifier($3)); smm_free($3); }
 
-    |   method_call_pre_parenthesis '.' T_IDENTIFIER '(' calling_method_argument_list ')' { TRACE $$ = ast_opr(T_METHOD_CALL, 3, $1, ast_identifier($3), $5); }
-    |   method_call_pre_parenthesis '.' T_IDENTIFIER '('                              ')' { TRACE $$ = ast_opr(T_METHOD_CALL, 3, $1, ast_identifier($3), ast_nop()); }
-    |   qualified_name '.' T_IDENTIFIER '(' calling_method_argument_list ')' { TRACE $$ = ast_opr(T_METHOD_CALL, 3, $1  , ast_identifier($3), $5); }
-    |   qualified_name '.' T_IDENTIFIER '('                              ')' { TRACE $$ = ast_opr(T_METHOD_CALL, 3, $1, ast_identifier($3), ast_nop()); }
-    |   special_name '.' T_IDENTIFIER '(' calling_method_argument_list ')' { TRACE $$ = ast_opr(T_METHOD_CALL, 3, $1  , ast_identifier($3), $5); }
-    |   special_name '.' T_IDENTIFIER '('                              ')' { TRACE $$ = ast_opr(T_METHOD_CALL, 3, $1, ast_identifier($3), ast_nop()); }
+    |   method_call_pre_parenthesis '.' T_IDENTIFIER '(' calling_method_argument_list ')' { TRACE $$ = ast_opr(T_METHOD_CALL, 3, $1, ast_string($3), $5); }
+    |   method_call_pre_parenthesis '.' T_IDENTIFIER '('                              ')' { TRACE $$ = ast_opr(T_METHOD_CALL, 3, $1, ast_string($3), ast_nop()); }
+    |   qualified_name '.' T_IDENTIFIER '(' calling_method_argument_list ')' { TRACE $$ = ast_opr(T_METHOD_CALL, 3, $1  , ast_string($3), $5); }
+    |   qualified_name '.' T_IDENTIFIER '('                              ')' { TRACE $$ = ast_opr(T_METHOD_CALL, 3, $1, ast_string($3), ast_nop()); }
+    |   special_name '.' T_IDENTIFIER '(' calling_method_argument_list ')' { TRACE $$ = ast_opr(T_METHOD_CALL, 3, $1  , ast_string($3), $5); }
+    |   special_name '.' T_IDENTIFIER '('                              ')' { TRACE $$ = ast_opr(T_METHOD_CALL, 3, $1, ast_string($3), ast_nop()); }
     |   qualified_name '(' calling_method_argument_list ')' { TRACE $$ = ast_opr(T_METHOD_CALL, 3, ast_nop(), $1, $3); }
     |   qualified_name '('                              ')' { TRACE $$ = ast_opr(T_METHOD_CALL, 3, ast_nop(), $1, ast_nop()); }
-    |   method_call '.' T_IDENTIFIER '(' calling_method_argument_list ')' { TRACE $$ = ast_opr(T_METHOD_CALL, 3, $1, ast_identifier($3), $5); }
-    |   method_call '.' T_IDENTIFIER '('                              ')' { TRACE $$ = ast_opr(T_METHOD_CALL, 3, $1, ast_identifier($3), ast_nop()); }
-    |   '(' expression ')' '.' T_IDENTIFIER '(' calling_method_argument_list ')' { TRACE $$ = ast_opr(T_METHOD_CALL, 3, $2, ast_identifier($5), $7); smm_free($5); }
-    |   '(' expression ')' '.' T_IDENTIFIER '('                              ')' { TRACE $$ = ast_opr(T_METHOD_CALL, 3, $2, ast_identifier($5), ast_nop()); smm_free($5); }
+    |   method_call '.' T_IDENTIFIER '(' calling_method_argument_list ')' { TRACE $$ = ast_opr(T_METHOD_CALL, 3, $1, ast_string($3), $5); }
+    |   method_call '.' T_IDENTIFIER '('                              ')' { TRACE $$ = ast_opr(T_METHOD_CALL, 3, $1, ast_string($3), ast_nop()); }
+    |   '(' expression ')' '.' T_IDENTIFIER '(' calling_method_argument_list ')' { TRACE $$ = ast_opr(T_METHOD_CALL, 3, $2, ast_string($5), $7); smm_free($5); }
+    |   '(' expression ')' '.' T_IDENTIFIER '('                              ')' { TRACE $$ = ast_opr(T_METHOD_CALL, 3, $2, ast_string($5), ast_nop()); smm_free($5); }
 
 
 ;

--- a/src/include/compiler/ast.h
+++ b/src/include/compiler/ast.h
@@ -93,6 +93,7 @@
     t_ast_element *ast_generate_tree(FILE *fp);
 
     t_ast_element *ast_string(char *value);
+    t_ast_element *ast_string_dup(t_ast_element *src);
     t_ast_element *ast_numerical(int value);
     t_ast_element *ast_identifier(char *var_name);
     t_ast_element *ast_opr(int opr, int nops, ...);


### PR DESCRIPTION
Fixes two things:
- The operands of the T_Import element node for the AST will always be filled
- Method names are returned as strings in stead of identifiers
