### PR TITLE
Fix method call cleanup

### DIFF
--- a/src/components/compiler/ast.c
+++ b/src/components/compiler/ast.c
@@ -87,6 +87,7 @@ static t_ast_element *ast_alloc_element(void) {
         yyerror("Out of memory");   /* LCOV_EXCL_LINE */
     }
     p->lineno = yylineno;
+    p->clean_handler = NULL;
 
     return p;
 }

--- a/src/components/compiler/ast_walker.c
+++ b/src/components/compiler/ast_walker.c
@@ -132,6 +132,14 @@ static void _ast_walker(t_ast_element *leaf, t_dll *output) {
                 case T_TOP_STATEMENTS :
                 case T_STATEMENTS :
                 case T_EXPRESSIONS :
+                    for (int i=0; i!=leaf->opr.nops; i++) {
+                        _ast_walker(leaf->opr.ops[i], output);
+                        if(leaf->opr.ops[i]->opr.oper != T_ASSIGNMENT && leaf->opr.ops[i]->clean_handler)
+                        {
+                            leaf->opr.ops[i]->clean_handler(output);
+                        }
+                    }
+                    break;
                 case T_USE_STATEMENTS :
                     for (int i=0; i!=leaf->opr.nops; i++) {
                         _ast_walker(leaf->opr.ops[i], output);
@@ -418,9 +426,9 @@ compare:
                     opr2 = asm_create_opr(ASM_LINE_TYPE_OP_REALNUM, NULL, nops);
                     dll_append(output, asm_create_codeline(VM_CALL_METHOD, 2, opr1, opr2));
 
+                    leaf->clean_handler = &ast_walker_call_method_clean_handler;
 
                     state.state = st_store;
-                    dll_append(output, asm_create_codeline(VM_POP_TOP, 0));
 
                     break;
 
@@ -438,6 +446,10 @@ compare:
         default :
             error_and_die(1, "Unknown AST type\n");
     }
+}
+
+void ast_walker_call_method_clean_handler(t_dll *output) {
+    dll_append(output, asm_create_codeline(VM_POP_TOP, 0));
 }
 
 /**

--- a/src/components/compiler/ast_walker.c
+++ b/src/components/compiler/ast_walker.c
@@ -409,11 +409,19 @@ compare:
 
                     node = leaf->opr.ops[1];
                     opr1 = asm_create_opr(ASM_LINE_TYPE_OP_STRING, node->string.value, 0);
-                    opr2 = asm_create_opr(ASM_LINE_TYPE_OP_REALNUM, NULL, leaf->opr.ops[2]->opr.nops);
+
+                    int nops = 0;
+                    if(leaf->opr.ops[2]->type == typeAstOpr ) {
+                        nops = leaf->opr.ops[2]->opr.nops;
+                    }
+
+                    opr2 = asm_create_opr(ASM_LINE_TYPE_OP_REALNUM, NULL, nops);
                     dll_append(output, asm_create_codeline(VM_CALL_METHOD, 2, opr1, opr2));
+
 
                     state.state = st_store;
                     dll_append(output, asm_create_codeline(VM_POP_TOP, 0));
+
                     break;
 
                 case T_ASSIGNMENT :

--- a/src/include/compiler/ast.h
+++ b/src/include/compiler/ast.h
@@ -28,6 +28,7 @@
 #define __AST_H__
 
     #include "compiler/class.h"
+    #include "general/dll.h"
     #include <stdio.h>
 
     // different kind of nodes we manage
@@ -73,10 +74,13 @@
         struct _ast_element *body;
     } methodNode;
 
+    typedef void (*t_clean_handler)(t_dll*);
+
     typedef struct _ast_element {
         nodeEnum type;              // Type of the node
         int flags;                  // Current flag (used for interpreting)
         unsigned long lineno;                 // Current line number for this AST element
+        t_clean_handler clean_handler;       //Function to clean up
         union {
             numericalNode numerical;    // constant int
             stringNode string;          // constant string

--- a/src/include/compiler/ast_walker.h
+++ b/src/include/compiler/ast_walker.h
@@ -30,7 +30,10 @@
     #include "compiler/ast.h"
     #include "compiler/assembler.h"
     #include "general/smm.h"
+    #include "general/dll.h"
 
     t_dll *ast_walker(t_ast_element *ast);
+
+    void ast_walker_call_method_clean_handler(t_dll *output);
 
 #endif

--- a/src/main/commands/bytecode.c
+++ b/src/main/commands/bytecode.c
@@ -78,7 +78,7 @@ static int _compile_file(const char *source_file, int sign, char *gpg_key) {
 
     // Write dot output file if needed
     if (write_dot) {
-        dot_dest_file = replace_extension(source_file, ".sf", "dot");
+        dot_dest_file = replace_extension(source_file, ".sf", ".dot");
         dot_generate(ast, dot_dest_file);
     }
 


### PR DESCRIPTION
T_METHOD_CALL doesn't assume anymore that the third node is always a parameters list node

Before, the T_METHOD_CALL always emitted a POP_TOP opcode, making it impossible to store that value.
