### PR TITLE
hashtable: Add copying of hashtables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ compile
 src/include/vm/vm_opcodes.c
 src/include/vm/vm_opcodes.h
 src/include/gitversion.h
+src/utmain

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libpcre3-dev libfcgi-dev libaugeas-dev libedit-dev libbz2-dev
   - sudo apt-get install -qq php5-cli
+  - sudo apt-get install -qq libcunit1-dev
 env:
     SAFFIRE_TEST_BIN=src/saffire
-script: ./configure && make && php unittests/unittester/run-saffire-tests.php unittests/tests/
+script: ./configure && make && make check && php unittests/unittester/run-saffire-tests.php unittests/tests/

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,6 +2,9 @@
 # INIT
 ########################################################################
 
+TESTS=utmain
+noinst_BINARIES=utmain
+
 # Set our optimization / debug flags
 if DEBUG
   AM_CFLAGS = -ggdb  -O0 -D__DEBUG
@@ -177,21 +180,37 @@ libgc_a_SOURCES = components/gc/gc.c
 
 
 ########################################################################
+# ../unittests/core
+########################################################################
+
+noinst_LIBRARIES += libtests.a
+libtests_a_SOURCES = ../unittests/core/main.c
+
+########################################################################
 # main/saffire
 ########################################################################
 
 SAFFIRE_LIBS = \
                  libobjects.a \
+                 libgeneral.a \
+                 libobjects.a \
+                 libgeneral.a \
                  libcompiler.a \
                  libfastcgi.a \
                  librepl.a \
                  libvm.a \
                  libgc.a \
-                 libmodules.a \
-                 libgeneral.a
+                 libgeneral.a \
+                 libmodules.a
 
 
-bin_PROGRAMS = saffire
+bin_PROGRAMS = saffire utmain
+
+utmain_LDADD = $(SAFFIRE_LIBS) -lcunit -lpthread
+
+utmain_SOURCES = \
+                    ../unittests/core/main.c \
+                    ../unittests/core/hashtable/hashtable.c
 
 saffire_LDADD = $(SAFFIRE_LIBS) $(edit_LIBS) $(augeas_LIBS) -lpthread
 

--- a/src/include/general/hashtable.h
+++ b/src/include/general/hashtable.h
@@ -52,6 +52,7 @@
         int element_count;                      // Number of elements in the hash table
         float load_factor;                      // ratio that has to be filled before resizing
         float resize_factor;                    // Resize factor
+        char copy_on_write;                    // Copy the buckets when written to
 
         struct _hashfuncs *hashfuncs;           // Pointer to actual hash functions
         t_hash_table_bucket *head;              // DLL head (for iteration)
@@ -70,11 +71,13 @@
         void *(*replace)(t_hash_table *ht, const char *key, void *value);   // Replace value to key
         void *(*remove)(t_hash_table *ht, const char *key);                 // Remove key
         void (*resize)(t_hash_table *ht, int new_bucket_count);             // Resize (and rehash) hashtable to new size
+        void (*deep_copy)(t_hash_table *ht);                                // Makes a deep copy of the buckets
     } t_hashfuncs;
 
 
     t_hash_table *ht_create(void);
     t_hash_table *ht_create_custom(int bucket_count, float load_factor, float resize_factor, t_hashfuncs *hashfuncs);
+    t_hash_table *ht_copy(t_hash_table *ht, int copy_on_write);
 
     int ht_exists(t_hash_table *ht, const char *key);
     void *ht_find(t_hash_table *ht, const char *key);

--- a/unittests/core/hashtable/hashtable.c
+++ b/unittests/core/hashtable/hashtable.c
@@ -1,0 +1,28 @@
+#include <CUnit/CUnit.h>
+#include <stdio.h>
+#include "hashtable.h"
+#include "../../src/include/general/hashtable.h"
+
+void test_hashtable_replace_does_not_affect_original_after_shallow_copy() {
+    t_hash_table *original = ht_create();
+    ht_add(original, "key", "original_value");
+
+    t_hash_table *copy = ht_copy(original, 1);
+
+    char *copy_before = (char *) ht_find(copy, "key");
+    CU_ASSERT(strcmp(copy_before, "original_value") == 0);
+
+    ht_replace(copy, "key", "replaced_value");
+    char *original_after = (char *) ht_find(original, "key");
+    CU_ASSERT(strcmp(original_after, "original_value") == 0);
+
+    char *copy_after = (char *) ht_find(copy, "key");
+    CU_ASSERT(strcmp(copy_after, "replaced_value") == 0);
+}
+
+
+void test_hashtable_init() {
+    CU_pSuite suite = CU_add_suite("hashtable", NULL, NULL);
+    CU_add_test(suite, "hashtable_copy", test_hashtable_replace_does_not_affect_original_after_shallow_copy);
+}
+

--- a/unittests/core/hashtable/hashtable.h
+++ b/unittests/core/hashtable/hashtable.h
@@ -1,0 +1,6 @@
+#ifndef __TEST_HASHTABLE_H
+#define __TEST_HASHTABLE_H
+
+void test_hashtable_init();
+
+#endif

--- a/unittests/core/main.c
+++ b/unittests/core/main.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+#include <CUnit/CUnit.h>
+#include "hashtable/hashtable.h"
+
+int main(int argc, char *argv[]) {
+
+    CU_initialize_registry();
+
+    test_hashtable_init();
+
+    CU_basic_run_tests();
+
+    unsigned int nr_of_fails = CU_get_number_of_tests_failed();
+    nr_of_fails += CU_get_number_of_failures();
+
+    CU_cleanup_registry();
+
+    return nr_of_fails > 0 ? 1 : 0;
+}


### PR DESCRIPTION
adds ht_copy() method to the hash library. This allows for copying of
hashtables. When copy on write is enabled, it does a shallow copy, until
the hash table is modified, and then does a deep copy.
