### PR TITLE
Add --no-write-bytecode to exec command

### DIFF
--- a/src/main/commands/exec.c
+++ b/src/main/commands/exec.c
@@ -41,6 +41,7 @@
 #include "debug.h"
 
 static int flag_no_verify = 0;
+int write_bytecode = 1;
 
 static int do_exec(void) {
     char *source_file = saffire_getopt_string(0);
@@ -58,7 +59,7 @@ static int do_exec(void) {
     int bytecode_exists = (access(bytecode_file, F_OK) == 0);
 
     if (! bytecode_exists || bytecode_get_timestamp(bytecode_file) != source_stat.st_mtime) {
-        bc = bytecode_generate_diskfile(source_file, bytecode_file, NULL);
+        bc = bytecode_generate_diskfile(source_file, write_bytecode ? bytecode_file : NULL, NULL);
     } else {
         bc = bytecode_load(bytecode_file, flag_no_verify);
     }
@@ -90,7 +91,8 @@ static int do_exec(void) {
 static const char help[]   = "Executes a Saffire script.\n"
                              "\n"
                              "Global settings:\n"
-                             "   --no-verify      Don't verify signature from bytecode file (if any)\n"
+                             "   --no-verify            Don't verify signature from bytecode file (if any)\n"
+                             "   --no-write-bytecode    Don't write bytecode to disk\n"
                              "\n"
                              "This command executes a saffire script or bytecode file.\n";
 
@@ -99,8 +101,13 @@ static void opt_no_verify(void *data) {
     flag_no_verify = 1;
 }
 
+static void opt_no_write_bytecode(void *data) {
+    write_bytecode = 0;
+}
+
 static struct saffire_option exec_options[] = {
     { "no-verify", "", no_argument, opt_no_verify},
+    { "no-write-bytecode", "", no_argument, opt_no_write_bytecode}
 };
 
 /* Config actions */

--- a/src/main/saffire.c
+++ b/src/main/saffire.c
@@ -162,7 +162,7 @@ int main(int argc, char *argv[]) {
         command = "help";
         argc = 0;
     } else if (argc >= 2) {
-        // If the action is 'dashed', remote the dashes. This will change
+        // If the action is 'dashed', remove the dashes. This will change
         // "saffire --help", into "saffire help"
         while (argv[1][0] == '-') argv[1]++;
         command = argv[1];


### PR DESCRIPTION
In some occassions, it's not convenient or even possible to write the
bytecode to the disk. Therefore, this adds an option to the exec command
to prevent that from happening.
