### PR TITLE
Add Gitter chat to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Saffire
 =======
 
 [![Build Status](https://travis-ci.org/saffire/saffire.png)](https://travis-ci.org/saffire/saffire)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/saffire/saffire?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 A new OO programming scripting language, based on primarily Python, PHP and Ruby. Its primary features:
 


### PR DESCRIPTION
I discovered Saffire actually does have Gitter chat, however there is no badge or link to it.

What do you think about adding the badge so people could find us there more easily? 
